### PR TITLE
WIP ACME server option helpers

### DIFF
--- a/acme-cli/src/main/java/io/micronaut/acme/cli/AcmeServerOption.java
+++ b/acme-cli/src/main/java/io/micronaut/acme/cli/AcmeServerOption.java
@@ -1,0 +1,31 @@
+package io.micronaut.acme.cli;
+
+import picocli.CommandLine;
+
+public class AcmeServerOption {
+
+    public static final String LE_PROD_URL = "https://acme-v02.api.letsencrypt.org/directory";
+
+    public static final String LE_STAGING_URL = "https://acme-staging-v02.api.letsencrypt.org/directory";
+
+    @CommandLine.Option(names = {"-u", "--url"}, required = true, showDefaultValue = CommandLine.Help.Visibility.ALWAYS, description = "Location of acme server to use.%nLet's Encrypt Prod :%n@|bold " + LE_PROD_URL + "|@%nLet's Encrypt Staging :%n@|bold " + LE_STAGING_URL + "|@")
+    private String serverUrl;
+
+    @CommandLine.Option(names = {"--lets-encrypt-prod"}, required = true, description = "Use the Let's Encrypt prod URL")
+    private boolean letsEncryptProd;
+
+    @CommandLine.Option(names = {"--lets-encrypt-staging"}, required = true, description = "Use the Let's Encrypt prod URL")
+    private boolean letsEncryptStaging;
+
+
+    public String serverUrl() {
+        if (letsEncryptProd) {
+            return LE_PROD_URL;
+        }
+        if (letsEncryptStaging) {
+            return LE_STAGING_URL;
+        }
+        return serverUrl;
+
+    }
+}

--- a/acme-cli/src/main/java/io/micronaut/acme/cli/CreateAccountCommand.java
+++ b/acme-cli/src/main/java/io/micronaut/acme/cli/CreateAccountCommand.java
@@ -44,8 +44,8 @@ public final class CreateAccountCommand implements Callable<Integer> {
     @CommandLine.Option(names = {"-k", "--key-dir"}, showDefaultValue = CommandLine.Help.Visibility.ALWAYS, defaultValue = "/tmp", description = "Directory to create/find the key to be used for this account.")
     String keyDir;
 
-    @CommandLine.Option(names = {"-u", "--url"}, required = true, showDefaultValue = CommandLine.Help.Visibility.ALWAYS, description = "Location of acme server to use.%nLet's Encrypt Prod :%n@|bold https://acme-v02.api.letsencrypt.org/directory|@%nLet's Encrypt Staging :%n@|bold https://acme-staging-v02.api.letsencrypt.org/directory|@")
-    String serverUrl;
+    @CommandLine.ArgGroup(multiplicity = "1")
+    AcmeServerOption acmeServerOption;
 
     @CommandLine.Option(names = {"-h", "--help"}, showDefaultValue = CommandLine.Help.Visibility.NEVER, defaultValue = "false", description = "Show usage of this command")
     boolean showHelp;
@@ -81,8 +81,8 @@ public final class CreateAccountCommand implements Callable<Integer> {
             return 1;
         }
 
-        System.out.println(">>> Opening session with " + serverUrl);
-        Session session = new Session(serverUrl);
+        System.out.println(">>> Opening session with " + acmeServerOption.serverUrl());
+        Session session = new Session(acmeServerOption.serverUrl());
 
         System.out.println(">>> Creating account with key and email : " + email);
         Account account = null;

--- a/acme-cli/src/main/java/io/micronaut/acme/cli/DeactivateAccountCommand.java
+++ b/acme-cli/src/main/java/io/micronaut/acme/cli/DeactivateAccountCommand.java
@@ -45,8 +45,8 @@ public final class DeactivateAccountCommand implements Callable<Integer> {
     @CommandLine.Option(names = {"-k", "--key-dir"}, showDefaultValue = CommandLine.Help.Visibility.ALWAYS, defaultValue = "/tmp", description = "Directory to find the key to be used for this account.")
     String keyDir;
 
-    @CommandLine.Option(names = {"-u", "--url"}, required = true, showDefaultValue = CommandLine.Help.Visibility.ALWAYS, description = "Location of acme server to use.%nLet's Encrypt Prod :%n@|bold https://acme-v02.api.letsencrypt.org/directory|@%nLet's Encrypt Staging :%n@|bold https://acme-staging-v02.api.letsencrypt.org/directory|@")
-    String serverUrl;
+    @CommandLine.ArgGroup(multiplicity = "1")
+    AcmeServerOption acmeServerOption;
 
     @CommandLine.Option(names = {"-h", "--help"}, showDefaultValue = CommandLine.Help.Visibility.NEVER, defaultValue = "false", description = "Show usage of this command")
     boolean showHelp;
@@ -56,6 +56,7 @@ public final class DeactivateAccountCommand implements Callable<Integer> {
 
     /**
      * Public interface for deactivating an account, arguments will be passed.
+     *
      * @param args arguments as defined above
      */
     public static void main(String[] args) {
@@ -66,9 +67,11 @@ public final class DeactivateAccountCommand implements Callable<Integer> {
 
     /**
      * Uses arguments passed to do all account deactivation.
+     *
      * @return exit code of the program
      */
     public Integer call() {
+        System.out.println(acmeServerOption.serverUrl());
         if (showHelp) {
             spec.commandLine().usage(System.out);
             return 0;
@@ -85,8 +88,8 @@ public final class DeactivateAccountCommand implements Callable<Integer> {
                 return 1;
             }
 
-            System.out.println(">>> Opening session with " + serverUrl);
-            Session session = new Session(serverUrl);
+            System.out.println(">>> Opening session with " + acmeServerOption.serverUrl());
+            Session session = new Session(acmeServerOption.serverUrl());
 
             System.out.println(">>> Logging in to account...");
             Login login = null;


### PR DESCRIPTION
Would have used @Mixin (see https://picocli.info/apidocs/picocli/CommandLine.Mixin.html), but I think I ran into issues with https://github.com/remkop/picocli/issues/450 (or a similar issue) where the mutually exclusive argument group was ignored when 'AcmeServerOption` was imported as a Mixin (vs directly using '@ArgGroup(multiplicity = "1")' where it was used.